### PR TITLE
Use SpawnLogic instead of custom RespawnSystemComponent

### DIFF
--- a/src/Scripts/Game/RespawnSystem/EPF_BasicSpawnLogic.c
+++ b/src/Scripts/Game/RespawnSystem/EPF_BasicSpawnLogic.c
@@ -1,8 +1,5 @@
-class EPF_BasicRespawnSystemComponentClass : EPF_BaseRespawnSystemComponentClass
-{
-}
-
-class EPF_BasicRespawnSystemComponent : EPF_BaseRespawnSystemComponent
+[BaseContainerProps(category: "Respawn")]
+class EPF_BasicSpawnLogic: EPF_BaseSpawnLogic
 {
 	[Attribute(defvalue: "{37578B1666981FCE}Prefabs/Characters/Core/Character_Base.et")]
 	ResourceName m_rDefaultPrefab;

--- a/src/Scripts/Game/RespawnSystem/SCR_SpawnRequestComponent.c
+++ b/src/Scripts/Game/RespawnSystem/SCR_SpawnRequestComponent.c
@@ -5,7 +5,7 @@ modded class SCR_SpawnRequestComponent
 	{
 		// Mute warnings on current minimalistic EPF respawn system "hotfix"
 		SCR_RespawnSystemComponent respawnSystem = SCR_RespawnSystemComponent.GetInstance();
-		if (respawnSystem && respawnSystem.IsInherited(EPF_BaseRespawnSystemComponent))
+		if (respawnSystem && respawnSystem.GetSpawnLogic() && respawnSystem.GetSpawnLogic().IsInherited(EPF_BaseSpawnLogic))
 			return;
 
 		super.OnPostInit(owner);


### PR DESCRIPTION
Hi, in my project I moved the respawn logic to use the (relatively new versus when this was originally made) SpawnLogic class. The base respawn system component removed the logic from itself and separated it into another class to keep it organized. I prefer this, and maybe you will too, so I've made a pull request that just moves the spawning logic to use this new setup. The only difference is you keep the SCR_RespawnSystemComponent and set the spawn logic to EPF_BasicSpawnLogic or EPF_BaseSpawnLogic. I have also done this for the everon life spawning logic and will submit a pull request there as well. 