### PR TITLE
GameEntity prefab inheritance restore

### DIFF
--- a/src/Prefabs/Weapons/Core/Attachment_Base.et
+++ b/src/Prefabs/Weapons/Core/Attachment_Base.et
@@ -1,4 +1,4 @@
-GenericEntity {
+GameEntity {
  ID "4BA426CBAED42A14"
  components {
   EPF_PersistenceComponent "{5A28749FA22EC9AC}" {


### PR DESCRIPTION
After the 1.2 game update, EPF was left with this prefab that broke the inheritance tree. This may be the only item that switched from GenericEntity to the GameEntity class name and wasn't caught when making the addon compatible with the update.