### PR TITLE
Fix slot loading prefab matching

### DIFF
--- a/src/Scripts/Game/Components/EPF_BaseInventoryStorageComponentSaveData.c
+++ b/src/Scripts/Game/Components/EPF_BaseInventoryStorageComponentSaveData.c
@@ -130,7 +130,7 @@ class EPF_BaseInventoryStorageComponentSaveData : EPF_ComponentSaveData
 			// Found matching entity, no need to spawn, just apply save-data
 			if (slot.m_pEntity &&
 				slotEntity &&
-				EPF_Utils.GetPrefabName(slotEntity).StartsWith(slot.m_pEntity.m_rPrefab))
+				EPF_Utils.GetPrefabGUID(EPF_Utils.GetPrefabName(slotEntity)) == EPF_Utils.GetPrefabGUID(slot.m_pEntity.m_rPrefab))
 			{
 				EPF_PersistenceComponent slotPersistence = EPF_Component<EPF_PersistenceComponent>.Find(slotEntity);
 				if (slotPersistence && !slotPersistence.Load(slot.m_pEntity, false))

--- a/src/Scripts/Game/Components/EPF_SlotManagerComponentSaveData.c
+++ b/src/Scripts/Game/Components/EPF_SlotManagerComponentSaveData.c
@@ -146,7 +146,7 @@ class EPF_SlotManagerComponentSaveData : EPF_ComponentSaveData
 		// Found matching entity, no need to spawn, just apply save-data
 		if (saveData &&
 			slotEntity &&
-			EPF_Utils.GetPrefabName(slotEntity).StartsWith(saveData.m_rPrefab))
+			EPF_Utils.GetPrefabGUID(EPF_Utils.GetPrefabName(slotEntity)) == EPF_Utils.GetPrefabGUID(saveData.m_rPrefab))
 		{
 			EPF_PersistenceComponent slotPersistence = EPF_Component<EPF_PersistenceComponent>.Find(slotEntity);
 			if (slotPersistence && !slotPersistence.Load(saveData, false))

--- a/src/Scripts/Game/Components/EPF_WeaponSlotComponentSaveData.c
+++ b/src/Scripts/Game/Components/EPF_WeaponSlotComponentSaveData.c
@@ -65,7 +65,7 @@ class EPF_WeaponSlotComponentSaveData : EPF_ComponentSaveData
 		// Found matching entity, no need to spawn, just apply save-data
 		if (m_pEntity &&
 			slotEntity &&
-			EPF_Utils.GetPrefabName(slotEntity).StartsWith(m_pEntity.m_rPrefab))
+			EPF_Utils.GetPrefabGUID(EPF_Utils.GetPrefabName(slotEntity)) == EPF_Utils.GetPrefabGUID(m_pEntity.m_rPrefab))
 		{
 			EPF_PersistenceComponent slotPersistence = EPF_Component<EPF_PersistenceComponent>.Find(slotEntity);
 			if (slotPersistence && !slotPersistence.Load(m_pEntity, false))


### PR DESCRIPTION
When a prefab is loading slots from the DB where the item already exists, the match always fails due to formatting differences in the resource names.

`EPF_Utils.GetPrefabName` returns a full prefab path, eg: `{FARTBALLS}Prefabs/Vest.et`

`m_rPrefab` returns a minimal prefab path, eg: `{FARTBALLS}.et`

The check for testing if the prefab is already spawned or not is using StartsWith, which will never be truthy when comparing these 2 formats. This causes a lot of bugs when loading items such as vest prefabs that have predefined slots

## Repro

- Wear a Alice GL vest: `18B8B9316B590643`
- Disconnect (forcing vest to save on character)
- Reconnect
    - the vest will load in as a belt because none of the slots can spawn
- All items in the vest are now gone
- Disconnect (saving the broken vest on the character)
- Reconnect
    - the vest will load in properly, with all items gone. the slots get loaded from the original prefab instead of from epf