### PR TITLE
Fix Unhandled Exception during UpdateEntities from SerializationSave

### DIFF
--- a/src/Scripts/Game/EPF_EntitySaveData.c
+++ b/src/Scripts/Game/EPF_EntitySaveData.c
@@ -489,7 +489,7 @@ class EPF_PersistentComponentSaveData
 	//------------------------------------------------------------------------------------------------
 	protected bool SerializationSave(SaveContext saveContext)
 	{
-		if (!saveContext.IsValid())
+		if (!saveContext || !saveContext.IsValid() || !m_pData)
 			return false;
 
 		saveContext.WriteValue("_type", EDF_DbName.Get(m_pData.Type()));


### PR DESCRIPTION
this is a bad practice and many other instances still need to be fixed but this one is a confirmed crasher.

2026-04-17 01:05:29.787 WORLD        : UpdateEntities
2026-04-17 01:05:29.787  WORLD        : PostFrame
2026-04-17 01:05:29.787   ENGINE    (E): Application crashed! Generated memory dump: /tmp/84c84d3d-382c-4738-88512da2-9d3c47e3.dmp
17.04 2026 01:05:29
Unhandled exception
Reason: Unknown
Class:      'EPF_PersistentComponentSaveData'
Function: 'WriteValue'
Stack trace:
Scripts/Game/EPF_EntitySaveData.c:495 Function SerializationSave
Scripts/Game/EPF_EntitySaveData.c:335 Function SerializationSave
Scripts/Game/Components/EPF_SlotManagerComponentSaveData.c:259 Function SerializationSave
Scripts/Game/EPF_EntitySaveData.c:496 Function SerializationSave
Scripts/Game/EPF_EntitySaveData.c:335 Function SerializationSave
Scripts/Game/Drivers/WebProxy/EDF_WebProxyDbDriverBase.c:502 Function Serialize
Scripts/Game/Persistence/RL_WebProxyDbDriverCallback.c:167 Function AddOrUpdateAsync
Scripts/Game/EDF_DbContext.c:61 Function AddOrUpdateAsync
Scripts/Game/EPF_PersistenceManager.c:609 Function AddOrUpdateAsync
Scripts/Game/Persistence/RL_PersistenceComponent.c:551 Function Save
Scripts/Game/EPF_PersistenceManager.c:348 Function AutoSaveTick
Scripts/Game/EPF_PersistenceManager.c:757 Function OnPostFrame
Scripts/Game/EPF_PersistenceManagerComponent.c:60 Function EOnPostFrame